### PR TITLE
0.3.7

### DIFF
--- a/readwrite/__version__.py
+++ b/readwrite/__version__.py
@@ -1,6 +1,6 @@
 __title__ = 'readwrite'
 __description__ = 'readwrite - Quickly read/write file in common formats'
-__version__ = '0.3.6'
+__version__ = '0.3.7'
 __author__ = 'Enzo CACERES'
 __author_email__ = 'enzo.caceres@crunchdao.com'
 __url__ = 'https://github.com/crunchdao/readwrite'

--- a/readwrite/registry.py
+++ b/readwrite/registry.py
@@ -3,7 +3,7 @@ import typing
 
 from .constants import LOGGER
 from .handlers.base import Handler
-
+from .utils import measure_duration
 
 class UnknownExtension(ValueError):
     def __init__(self, extension: str):
@@ -24,42 +24,26 @@ class Registry:
     def read(self, path: str, **kwargs):
         handler = self.get(path)
 
-        LOGGER.debug(
-            "read - handler=%s path=`%s`",
-            handler.name, path
-        )
-
-        return handler.read(path, **kwargs)
+        with measure_duration("read", handler.name, path):
+            return handler.read(path, **kwargs)
 
     def read_as(self, path: str, extension: str, **kwargs):
         handler = self.get(extension)
 
-        LOGGER.debug(
-            "read - handler=%s path=`%s`",
-            handler.name, path
-        )
-
-        return handler.read(path, **kwargs)
+        with measure_duration("read_as", handler.name, path):
+            return handler.read(path, **kwargs)
 
     def write(self, x: typing.Any, path: str, **kwargs):
         handler = self.get(path)
 
-        LOGGER.debug(
-            "write - handler=%s path=`%s`",
-            handler.name, path
-        )
-
-        handler.write(x, path, **kwargs)
+        with measure_duration("write", handler.name, path):
+            handler.write(x, path, **kwargs)
 
     def write_as(self, x: typing.Any, path: str, extension: str, **kwargs):
         handler = self.get(extension)
 
-        LOGGER.debug(
-            "write - handler=%s path=`%s`",
-            handler.name, path
-        )
-
-        handler.write(x, path, **kwargs)
+        with measure_duration("write_as", handler.name, path):
+            handler.write(x, path, **kwargs)
 
     def get(self, path_or_extension: str):
         try:

--- a/readwrite/utils.py
+++ b/readwrite/utils.py
@@ -1,0 +1,24 @@
+import time
+import contextlib
+
+from .constants import LOGGER
+
+
+@contextlib.contextmanager
+def measure_duration(operation: str, handler_name: str, path: str):
+    start_time = time.time()
+
+    LOGGER.debug(
+        "%s - handler=%s path=`%s`",
+        operation, handler_name, path
+    )
+
+    yield
+
+    end_time = time.time()
+    duration = end_time - start_time
+
+    LOGGER.debug(
+        "%s - handler=%s path=`%s` duration=%.4fs",
+        operation, handler_name, path, duration
+    )


### PR DESCRIPTION
## Features

- show time took to read/write a file as debug

## Demo

```bash
$ readf --debug tests/dummy/hello.parquet
DEBUG:readwrite:read - handler=parquet path=`tests/dummy/hello.parquet`
DEBUG:readwrite:read - handler=parquet path=`tests/dummy/hello.parquet` duration=0.3727s
available variables:
df: DataFrame
df_path: tests/dummy/hello.parquet

>>>
```